### PR TITLE
Ensure observations columns exist on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
    uvicorn floralink_backend.main:app --reload
    ```
    默认监听 `http://127.0.0.1:8000`，所有 API 以 `/api` 为前缀。
+   > 应用会在启动时自动检查 `observations` 表是否包含 `location_name` 与 `photo_url` 字段，若缺失会自动新增。部署后请重启服务以确保数据库结构更新。
 
 ### 运行测试
 ```bash

--- a/backend/floralink_backend/main.py
+++ b/backend/floralink_backend/main.py
@@ -1,12 +1,50 @@
 """Entry point for the FloraLink FastAPI application."""
+import logging
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import SQLAlchemyError
 
 from .core.config import settings
 from .database import Base, engine
 from .routers import auth, communities, gardens, observations, plants, users
 
+logger = logging.getLogger(__name__)
+
+
+def _ensure_observations_columns() -> None:
+    """Add newly required columns to the observations table if they are missing."""
+
+    try:
+        inspector = inspect(engine)
+        if not inspector.has_table("observations"):
+            return
+
+        existing_columns = {column["name"] for column in inspector.get_columns("observations")}
+        statements = []
+
+        if "location_name" not in existing_columns:
+            statements.append((text("ALTER TABLE observations ADD COLUMN location_name VARCHAR(255)"), "location_name"))
+        if "photo_url" not in existing_columns:
+            statements.append((text("ALTER TABLE observations ADD COLUMN photo_url VARCHAR(500)"), "photo_url"))
+
+        if not statements:
+            return
+
+        added_columns = []
+        with engine.begin() as connection:
+            for statement, column_name in statements:
+                connection.execute(statement)
+                added_columns.append(column_name)
+        logger.info("Ensured observations table has required columns: %s", ", ".join(added_columns))
+    except SQLAlchemyError:
+        logger.exception("Failed to ensure observations table schema is up to date")
+        raise
+
+
 Base.metadata.create_all(bind=engine)
+_ensure_observations_columns()
 
 app = FastAPI(title=settings.app_name)
 

--- a/backend/floralink_backend/models.py
+++ b/backend/floralink_backend/models.py
@@ -116,9 +116,11 @@ class Observation(Base):
     species_id = Column(Integer, ForeignKey("plant_species.id", ondelete="SET NULL"), nullable=True)
     latitude = Column(Float, nullable=False)
     longitude = Column(Float, nullable=False)
+    location_name = Column(String(255), nullable=True)
     observed_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     note = Column(Text, nullable=True)
     is_public = Column(Boolean, default=True, nullable=False)
+    photo_url = Column(String(500), nullable=True)
 
     reporter = relationship("User", back_populates="observations")
     species = relationship("PlantSpecies", back_populates="observations")

--- a/backend/floralink_backend/schemas.py
+++ b/backend/floralink_backend/schemas.py
@@ -152,9 +152,11 @@ class ObservationBase(BaseModel):
     species_id: Optional[int] = None
     latitude: float
     longitude: float
+    location_name: Optional[str] = None
     note: Optional[str] = None
     is_public: bool = True
     observed_at: Optional[datetime] = None
+    photo_url: Optional[str] = None
 
 
 class ObservationCreate(ObservationBase):


### PR DESCRIPTION
## Summary
- ensure the observations table includes the new location_name and photo_url columns during app startup
- extend the Observation ORM and Pydantic models to expose the new optional fields
- document the automatic column backfill behaviour in the backend README

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68ca0f1967848328ba4c2249f9ba6a69